### PR TITLE
move the import_all on the views to app.py

### DIFF
--- a/{{ cookiecutter.slug }}/{{ cookiecutter.pkg_name }}/app.py
+++ b/{{ cookiecutter.slug }}/{{ cookiecutter.pkg_name }}/app.py
@@ -9,6 +9,7 @@ from whitenoise import WhiteNoise
 
 from {{ cookiecutter.pkg_name }}.database import db, migrate
 from {{ cookiecutter.pkg_name }}.l10n import babel, store_locale
+from {{ cookiecutter.pkg_name }}.utils import import_all
 from {{ cookiecutter.pkg_name }}.views import blueprint
 
 
@@ -70,6 +71,7 @@ def create_app(config=None):
     )
 
     # Register views
+    import_all("{{ cookiecutter.pkg_name }}.views")
     app.register_blueprint(blueprint)
     app.register_blueprint(healthz, url_prefix="/healthz")
 

--- a/{{ cookiecutter.slug }}/{{ cookiecutter.pkg_name }}/views/__init__.py
+++ b/{{ cookiecutter.slug }}/{{ cookiecutter.pkg_name }}/views/__init__.py
@@ -1,7 +1,4 @@
 from flask import Blueprint
 
-from {{ cookiecutter.pkg_name }}.utils import import_all
-
 
 blueprint = Blueprint("root", __name__)
-import_all("{{ cookiecutter.pkg_name }}.views")


### PR DESCRIPTION
previously, the import_all on the views was done in the views
__init__.py, but this caused a circualar import error when trying to
add something like "from tahrir.app import csrf" to a view (i.e. root.py)

moving the import_all to just before registrering the blueprints is how
it is done in noggin -- so just copied that pattern in this commit.

Signed-off-by: Ryan Lerch <rlerch@redhat.com>